### PR TITLE
Feature/cost-map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,19 @@ target_link_libraries(depth-test
     Eigen3::Eigen
     )
 
+add_executable(cost-map-test test/cpp/cost_map_test.cpp)
+target_link_libraries(cost-map-test
+    ${PROJECT_NAME}
+    ${TORCH_LIBRARIES}
+    ${OpenCV_LIBRARIES}
+    jsoncpp_lib
+    ${glog_LIBRARIES}
+    ${GTEST_LIBRARIES}
+    TBB::tbb
+    pthread
+    Eigen3::Eigen
+    )
+
 add_executable(preprocess-test test/cpp/preprocess.cpp)
 target_link_libraries(preprocess-test
     ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(${PROJECT_NAME}
     utils/resize.cpp
     utils/normalize.cpp
     utils/interpolate.cpp
+    utils/average.cpp
     utils/mode.cpp
     utils/max.cpp
 )
@@ -66,6 +67,7 @@ target_link_libraries(depth-test
     jsoncpp_lib
     ${glog_LIBRARIES}
     ${GTEST_LIBRARIES}
+    TBB::tbb
     pthread
     Eigen3::Eigen
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(
     ${glog_INCLUDE_DIRS}
     ${GTEST_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIR}
+    ${TBB_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME}
@@ -41,6 +42,8 @@ add_library(${PROJECT_NAME}
     utils/resize.cpp
     utils/normalize.cpp
     utils/interpolate.cpp
+    utils/mode.cpp
+    utils/max.cpp
 )
 
 add_executable(semantics-test test/cpp/semantics_model.cpp)

--- a/config/cost_map.json
+++ b/config/cost_map.json
@@ -1,6 +1,7 @@
 {
-    "width": 256,
-    "height": 256,
+    "width": 320,
+    "height": 180,
+    "kernel": 4,
     "num_classes": 19,
     "classes":
     {
@@ -99,7 +100,5 @@
             "id": "bicycle",
             "cost": 255
         }
-
-
     }
 }

--- a/config/cost_map.json
+++ b/config/cost_map.json
@@ -1,8 +1,11 @@
 {
-    "width": 320,
-    "height": 180,
-    "kernel": 4,
-    "num_classes": 19,
+    "sizing":
+    {
+        "width": 320,
+        "height": 180,
+        "kernel": 4,
+        "num_classes": 19
+    },
     "classes":
     {
         "0":

--- a/include/waz/average.hpp
+++ b/include/waz/average.hpp
@@ -1,0 +1,19 @@
+/*!
+* Author:  Jason Hughes
+* Date:    July 2024
+* About:   Module to calculate average of an opencv matrix
+*
+* Package: Waz
+*/
+
+#ifndef AVERAGE_HPP
+#define AVERAGE_HPP
+
+#include <opencv2/opencv.hpp>
+
+struct Average
+{
+    Average() = default;
+    double operator()(cv::Mat& mat) noexcept;
+};
+#endif

--- a/include/waz/cost_map.hpp
+++ b/include/waz/cost_map.hpp
@@ -48,9 +48,9 @@ class CostMap
         struct SemanticCost
         {
             cv::Mat& mat;
-            CostMap* cost_map;
+            std::map<int, LabelMap>& label_map;
 
-            SemanticCost(cv::Mat& m, CostMap* cm);
+            SemanticCost(cv::Mat& m, std::map<int,LabelMap>& lm);
             SemanticCost(SemanticCost& s, tbb::split);
 
             void operator()(const tbb::blocked_range2d<int>& r);
@@ -73,6 +73,10 @@ class CostMap
     private:
         void costFromSemantics(cv::Mat& semantics, cv::Mat& cost_map);
         void costFromDepth(cv::Mat& depth, cv::Mat& cost_map); 
+
+        cv::Mat semantic_map_;
+        cv::Mat depth_map_;
+
         CostMapParams params_;
         Average average_;
         Mode mode_;

--- a/include/waz/cost_map.hpp
+++ b/include/waz/cost_map.hpp
@@ -11,9 +11,15 @@
 #include <string>
 #include <map>
 #include <Eigen/Dense>
+#include <opencv2/opencv.hpp>
+#include <tbb/parallel_reduce.h>
+#include <tbb/blocked_range2d.h>
 
 #include "label_map.hpp"
 #include "params.hpp"
+#include "model.hpp"
+#include "mode.hpp"
+#include "max.hpp"
 
 class CostMap
 {
@@ -22,25 +28,41 @@ class CostMap
         //CostMap(int width, int height);
         CostMap(std::string path);
 
+        struct Initializer
+        {
+            cv::Mat& mat;
+            CostMap* cost_map;
+
+            Initializer(cv::Mat& m, CostMap* cm);
+            Initializer(Initializer& s, tbb::split);
+
+            void operator()(const tbb::blocked_range2d<int>& r);
+        };
+
         struct CostMapParams : public Params 
         {
             using Params::Params;
 
             int width, height;
+            int kernel;
             std::map<int, LabelMap> label_map;
 
             void setParams() noexcept;
         };
 
-        int getSize();
-        int getCostMap();
+        LabelMap getLabelMap(uint8_t label);
+
+        friend struct Initializer;
 
     private:
         static const int SIZE = 256;
         Eigen::Matrix<uint8_t, SIZE, SIZE> cost_map_;
     
         void searchDepthForObjects(const Eigen::MatrixXf& depth);
-
+        cv::Mat kernalizeMask(const cv::Mat& mask, Model model) noexcept;
+        
         CostMapParams params_;
+        Mode mode_;
+        Max max_;
 };
 #endif

--- a/include/waz/depth.hpp
+++ b/include/waz/depth.hpp
@@ -28,7 +28,7 @@ class DepthManager : protected NetworkManager
     public:
         DepthManager(std::string params_path, std::string model_id = "depth");
 
-        cv::Mat inference(cv::Mat& img);
+        cv::Mat inference(cv::Mat img);
 
         struct DepthParams: public Params
         {   

--- a/include/waz/max.hpp
+++ b/include/waz/max.hpp
@@ -1,0 +1,21 @@
+/*!
+* Author: Jason Hughes
+* Date:   July 2024
+* About:  Find the Max value of 
+*         an opencv matrix.
+*
+* Package: Waz
+*/
+
+#ifndef MAX_HPP
+#define MAX_HPP
+
+#include <opencv2/opencv.hpp>
+
+struct Max
+{
+    Max() = default;
+
+    uint8_t operator()(cv::Mat& mat) noexcept;
+};
+#endif

--- a/include/waz/mode.hpp
+++ b/include/waz/mode.hpp
@@ -1,0 +1,22 @@
+/*!
+* Author:  Jason Hughes
+* Date:    July 2024
+* About:   A quick object to calculate mode
+*          from a cv::Mat, typed.
+*
+* Package: Waz
+*/
+
+#ifndef MODE_HPP
+#define MODE_HPP
+
+#include <opencv2/opencv.hpp>
+#include <unordered_map>
+
+struct Mode
+{
+    Mode() = default;
+
+    uint8_t operator()(cv::Mat& mat);
+};
+#endif

--- a/include/waz/model.hpp
+++ b/include/waz/model.hpp
@@ -1,0 +1,17 @@
+/*! 
+* Author:  Jason Hughes
+* Date:    July 2024
+* About:   enumerate the models
+*
+* Package: Waz
+*/
+
+#ifndef MODEL_HPP
+#define MODEL_HPP
+
+enum Model
+{
+    DEPTH,
+    SEMANTICS
+};
+#endif 

--- a/include/waz/semantics.hpp
+++ b/include/waz/semantics.hpp
@@ -27,7 +27,7 @@ class SemanticsManager : protected NetworkManager
     public:
 
         SemanticsManager(std::string path, std::string model_id = "semantics");
-        cv::Mat inference(cv::Mat& img);
+        cv::Mat inference(cv::Mat img);
 
         struct SemanticParams : public Params
         {

--- a/src/cost_map.cpp
+++ b/src/cost_map.cpp
@@ -13,10 +13,55 @@ CostMap::CostMap(std::string path) : params_(path)
 
 }
 
+
+cv::Mat CostMap::kernalizeMask(const cv::Mat& mask, Model model) noexcept
+{
+    // can this be parallelized using TBB???
+    cv::Mat map(params_.height, params_.width, CV_8U);
+
+    for(int i=0, i_map=0; i < (params_.height - params_.kernel) ; i += params_.kernel, ++i_map)
+    {
+        for (int j=0, j_map=0; j < (params_.width - params_.kernel) ; i += params_.kernel, ++j_map)
+        {
+            uint8_t val;
+            cv::Mat submask = mask(cv::Rect(i, j, params_.kernel, params_.kernel));
+            if (model == Model::SEMANTICS)
+            {
+                val = mode_(submask);
+            }
+            else if (model == Model::DEPTH)
+            {
+                val = max_(submask);
+            }
+            map.at<int>(i_map, j_map) = val;
+        }
+    }
+
+    return map;
+}
+
+CostMap::Initializer::Initializer(cv::Mat& m, CostMap* cm) : mat(m), cost_map(cm) { }
+
+CostMap::Initializer::Initializer(Initializer& s, tbb::split) : mat(s.mat) { }
+
+void CostMap::Initializer::operator()(const tbb::blocked_range2d<int>& r)
+{
+    for (int i = r.rows().begin(); i != r.rows().end(); ++i)
+    {
+        for (int j = r.cols().begin(); j != r.cols().end(); ++j)
+        {
+            uint8_t label = mat.at<uint8_t>(i,j);
+            LabelMap lm = cost_map->params_.label_map[label];
+            mat.at<uint8_t>(i, j) = lm.cost;
+        }
+    }
+}   
+
 void CostMap::CostMapParams::setParams() noexcept
 {
     width = params_map_["width"].asInt();
     height = params_map_["height"].asInt();
+    kernel = params_map_["kernel"].asInt();
 
     int num_classes = params_map_["num_classes"].asInt();
 
@@ -29,3 +74,8 @@ void CostMap::CostMapParams::setParams() noexcept
         label_map[i] = LabelMap(label, cost, i);
     }
 }
+
+LabelMap CostMap::getLabelMap(uint8_t label)
+{
+    return params_.label_map[label];
+}   

--- a/src/cost_map.cpp
+++ b/src/cost_map.cpp
@@ -10,21 +10,19 @@
 
 CostMap::CostMap(std::string path) : params_(path)
 {
-
+    params_.setParams();
 }
-
 
 cv::Mat CostMap::kernalizeMask(const cv::Mat& mask, Model model) noexcept
 {
     // can this be parallelized using TBB???
-    cv::Mat map(params_.height, params_.width, CV_8U);
-
-    for(int i=0, i_map=0; i < (params_.height - params_.kernel) ; i += params_.kernel, ++i_map)
+    cv::Mat map(params_.height, params_.width, CV_8UC1);
+    for(int i=0, i_map=0; i < (mask.rows - params_.kernel) ; i += params_.kernel, ++i_map)
     {
-        for (int j=0, j_map=0; j < (params_.width - params_.kernel) ; i += params_.kernel, ++j_map)
+        for (int j=0, j_map=0; j < (mask.cols - params_.kernel) ; j += params_.kernel, ++j_map)
         {
             uint8_t val;
-            cv::Mat submask = mask(cv::Rect(i, j, params_.kernel, params_.kernel));
+            cv::Mat submask = mask(cv::Rect(j, i, params_.kernel, params_.kernel));
             if (model == Model::SEMANTICS)
             {
                 val = mode_(submask);
@@ -33,18 +31,78 @@ cv::Mat CostMap::kernalizeMask(const cv::Mat& mask, Model model) noexcept
             {
                 val = max_(submask);
             }
-            map.at<int>(i_map, j_map) = val;
+            map.at<uchar>(i_map, j_map) = val;
         }
     }
 
     return map;
 }
 
-CostMap::Initializer::Initializer(cv::Mat& m, CostMap* cm) : mat(m), cost_map(cm) { }
+cv::Mat CostMap::getCostMap(cv::Mat& depth, cv::Mat& semantics) noexcept
+{
+    cv::Mat depth_down_res = kernalizeMask(depth, Model::DEPTH);
+    cv::Mat semantics_down_res = kernalizeMask(semantics, Model::SEMANTICS);
 
-CostMap::Initializer::Initializer(Initializer& s, tbb::split) : mat(s.mat) { }
+    cv::Mat cost_map(params_.height, params_.width, CV_8UC1);
 
-void CostMap::Initializer::operator()(const tbb::blocked_range2d<int>& r)
+    // must initialize cost_map from semantics before depth
+    costFromSemantics(semantics_down_res, cost_map);
+    costFromDepth(depth_down_res, cost_map);
+
+    return cost_map;
+}
+
+void CostMap::costFromSemantics(cv::Mat& semantics, cv::Mat& cost_map)
+{
+    SemanticCost semantic_cost(semantics, this);
+    tbb::parallel_reduce(tbb::blocked_range2d<int>(0, semantics.rows, 0, semantics.cols), semantic_cost);
+}
+
+void CostMap::costFromDepth(cv::Mat& depth, cv::Mat& cost_map)
+{
+    // get the pixel where the robot is
+    int middle[2] = {params_.width / 2, params_.height};
+
+    cv::Mat rect = depth(cv::Rect(middle[0] - 10, middle[1] - 20, 20, 20));
+    double avg = average_(rect);
+
+    DepthCost depth_cost(cost_map, depth, avg);
+    tbb::parallel_reduce(tbb::blocked_range2d<int>(0, depth.rows, 0, depth.cols), depth_cost); 
+}
+
+
+CostMap::DepthCost::DepthCost(cv::Mat& cm, cv::Mat& d, double a) : cost_map(cm), depth(d), avg(a) { }
+
+CostMap::DepthCost::DepthCost(DepthCost& dc, tbb::split) : cost_map(dc.cost_map), depth(dc.depth), avg(dc.avg) { }
+
+void CostMap::DepthCost::operator()(const tbb::blocked_range2d<int>& r)
+{ 
+    for (int i = r.rows().begin(); i != r.rows().end(); ++i)
+    {
+        for (int j = r.cols().begin(); j != r.cols().end(); ++j)
+        {
+            uint8_t cost_map_val = cost_map.at<uint8_t>(i,j);
+            uint8_t depth_val = depth.at<uint8_t>(i,j);
+
+            if (cost_map_val != 255)
+            {
+                if ((depth_val > (avg + 10)) || (depth_val < (avg - 10)))
+                {
+                    cost_map.at<uint8_t>(i,j) = 255;
+                }
+            }
+        }
+    }
+}
+
+void CostMap::DepthCost::join(const DepthCost& other) { }
+
+
+CostMap::SemanticCost::SemanticCost(cv::Mat& m, CostMap* cm) : mat(m), cost_map(cm) { }
+
+CostMap::SemanticCost::SemanticCost(SemanticCost& s, tbb::split) : mat(s.mat) { }
+
+void CostMap::SemanticCost::operator()(const tbb::blocked_range2d<int>& r)
 {
     for (int i = r.rows().begin(); i != r.rows().end(); ++i)
     {
@@ -55,15 +113,19 @@ void CostMap::Initializer::operator()(const tbb::blocked_range2d<int>& r)
             mat.at<uint8_t>(i, j) = lm.cost;
         }
     }
-}   
+} 
+
+void CostMap::SemanticCost::join(const SemanticCost& other) { }
+
+// call with tbb::parallel_reduce(tbb::blocked_range2d<int>(0,ROWS, 0,COlS), init)
 
 void CostMap::CostMapParams::setParams() noexcept
 {
-    width = params_map_["width"].asInt();
-    height = params_map_["height"].asInt();
-    kernel = params_map_["kernel"].asInt();
+    width = params_map_["sizing"]["width"].asInt();
+    height = params_map_["sizing"]["height"].asInt();
+    kernel = params_map_["sizing"]["kernel"].asInt();
 
-    int num_classes = params_map_["num_classes"].asInt();
+    int num_classes = params_map_["sizing"]["num_classes"].asInt();
 
     for (uint8_t i=0; i < num_classes; ++i)
     {
@@ -75,7 +137,3 @@ void CostMap::CostMapParams::setParams() noexcept
     }
 }
 
-LabelMap CostMap::getLabelMap(uint8_t label)
-{
-    return params_.label_map[label];
-}   

--- a/src/depth.cpp
+++ b/src/depth.cpp
@@ -70,7 +70,7 @@ cv::Mat DepthManager::tensorToCv(const at::Tensor& tensor) const noexcept
     return img;
 }
 
-cv::Mat DepthManager::inference(cv::Mat& img)
+cv::Mat DepthManager::inference(cv::Mat img)
 {
     int h = img.rows;
     int w = img.cols;

--- a/src/network_manager.cpp
+++ b/src/network_manager.cpp
@@ -10,7 +10,7 @@
 NetworkManager::NetworkManager(std::string params_path, std::string model_id) : params_(params_path)
 {
     // have the constructor load the params json and set them 
-    google::InitGoogleLogging("/home/jason/.waz/");
+    // google::InitGoogleLogging("/home/jason/.waz/");
     model_id_ = model_id;
     params_.setParams(model_id);
     //device_ = at::kCUDA;

--- a/src/semantics.cpp
+++ b/src/semantics.cpp
@@ -51,7 +51,7 @@ cv::Mat SemanticsManager::tensorToCv(const at::Tensor& tensor) const noexcept
 {
     int rows = tensor.size(0);
     int cols = tensor.size(1);
-
+    
     cv::Mat img(rows, cols, CV_8UC1);
     std::memcpy(img.data, tensor.data_ptr<uint8_t>(), sizeof(torch::kUInt8) * tensor.numel());
 
@@ -64,11 +64,11 @@ at::Tensor SemanticsManager::postProcess(at::Tensor& result)
     return torch::argmax(result, 0).to(torch::kUInt8);
 }
 
-cv::Mat SemanticsManager::inference(cv::Mat& img)
+cv::Mat SemanticsManager::inference(cv::Mat img)
 {   
     int h = img.rows;
     int w = img.cols;
-
+   
     at::Tensor input, result;
     normalize_(img, params_.mean, params_.std);
     resize_(img, params_.input_width, params_.input_height);

--- a/test/cpp/cost_map_test.cpp
+++ b/test/cpp/cost_map_test.cpp
@@ -1,0 +1,44 @@
+/*!
+* Author:  Jason Hughes
+* Date:    July 2024
+* About:   Test script for the cost map module
+*
+* Package: Waz
+*/
+
+#include <opencv2/opencv.hpp>
+#include "waz/cost_map.hpp"
+#include "waz/depth.hpp"
+#include "waz/semantics.hpp"
+
+int main(int argc, char **argv)
+{
+
+    google::InitGoogleLogging("/home/jason/.waz/");
+    DepthManager depth("/home/jason/config/networks.json");
+    SemanticsManager semantics("/home/jason/config/networks.json");
+    
+    CostMap cost_map("/home/jason/config/cost_map.json");
+    
+    cv::Mat test_img = cv::imread("/home/jason/test/imgs/test-img-1.png", cv::IMREAD_COLOR);
+    if (test_img.empty())
+    {
+        std::cout << "[TEST] Cound not find test image" << std::endl;
+        return -1;
+    }
+    else
+    {
+        std::cout << "[TEST] Loaded test image" << std::endl;
+    }
+ 
+    cv::Mat depth_mat = depth.inference(test_img);
+    cv::Mat semantics_mat = semantics.inference(test_img);
+
+    cv::Mat cost_map_mat = cost_map.getCostMap(depth_mat, semantics_mat);
+
+    cv::imshow("Cost Map", cost_map_mat);
+    cv::waitKey(0);
+    cv::destroyAllWindows();
+
+    return 0;
+}

--- a/test/cpp/depth_model.cpp
+++ b/test/cpp/depth_model.cpp
@@ -8,6 +8,8 @@
 */
 
 #include "waz/depth.hpp"
+#include "waz/model.hpp"
+#include "waz/cost_map.hpp"
 
 void print_tensor_dtype(const torch::Tensor& tensor) 
 {
@@ -53,6 +55,7 @@ void print_tensor_dtype(const torch::Tensor& tensor)
 int main(int argc, char **argv)
 {
     DepthManager depth("/home/jason/config/networks.json", "depth");
+    CostMap cost_map("/home/jason/config/cost_map.json");
 
     cv::Mat test_img = cv::imread("/home/jason/test/imgs/test-img-1.png", cv::IMREAD_COLOR);
     if (test_img.empty())
@@ -66,8 +69,9 @@ int main(int argc, char **argv)
     }
     std::cout << "[TEST] Running image through depth model..." << std::endl;
     cv::Mat result = depth.inference(test_img);
-    
-    cv::imshow("depth", result);
+    cv::Mat kern = cost_map.kernalizeMask(result, Model::DEPTH);
+    std::cout << kern.rows << "  " << kern.cols << std::endl;
+    cv::imshow("depth", kern);
     cv::waitKey(0);
     cv::destroyAllWindows();
 

--- a/utils/average.cpp
+++ b/utils/average.cpp
@@ -1,0 +1,27 @@
+/*! 
+* Author:  Jason Hughes
+* Date:    July 2024
+* About:   Module to calculate the average
+*          of an opencv matrix.
+*
+* Package: Waz
+*/
+
+#include <waz/average.hpp>
+
+double Average::operator()(cv::Mat& mat) noexcept 
+{
+    int sum = 0;
+    int count = 0;
+
+    for (int i = 0; i < mat.rows; ++i)
+    {
+        for (int j = 0; j < mat.cols; ++j)
+        {
+            sum += mat.at<uchar>(i,j);
+            count ++;
+        }
+    }
+    
+    return sum /(double) count;
+}

--- a/utils/max.cpp
+++ b/utils/max.cpp
@@ -1,0 +1,29 @@
+/*!
+* Author:  Jason Hughes
+* Date:    July 2024
+* About:   find the max value of a 
+*          cv Matrix.
+*
+* Package: Waz
+*/
+
+#include "waz/max.hpp"
+
+uint8_t Max::operator()(cv::Mat& mat) noexcept
+{
+    uint8_t max;
+    max = mat.at<uint8_t>(0,0);
+
+    for (int i = 0; i < mat.rows; i++)
+    {
+        for (int j = 0; j < mat.cols; j++)
+        {
+            if (mat.at<uint8_t>(i,j) > max)
+            {
+                max = mat.at<uint8_t>(i,j);
+            }
+        }
+    }
+
+    return max;
+}

--- a/utils/mode.cpp
+++ b/utils/mode.cpp
@@ -1,0 +1,36 @@
+/*!
+* Author:  Jason Hughes
+* Date:    July 2024
+* About:   calculate the mode of a 
+*          cv matrix
+*
+* Package: Waz 
+*/
+
+#include "waz/mode.hpp"
+
+uint8_t Mode::operator()(cv::Mat& mat)
+{
+    std::unordered_map<uint8_t, int> frequency;
+    for (int i = 0; i < mat.rows; ++i) 
+    {
+        for (int j = 0; j < mat.cols; ++j)
+        {
+            uint8_t value = mat.at<int>(i, j);  
+            frequency[value]++;
+        }
+    }
+    uint8_t mode = mat.at<uint8_t>(0, 0);  
+    int max_count = frequency[mode];
+    
+    for (const auto& kv : frequency) 
+    {
+        if (kv.second > max_count) 
+        {
+            mode = kv.first;
+            max_count = kv.second;
+        }
+    }
+
+    return mode;
+}


### PR DESCRIPTION
This module takes in the depth and semantics model output at camera resolution. It then down-reses them to 1/4 resolution. Depth is downresed based on max value of the 4x4 grid and the semantics id downresed based on the model of the 4x4 grid. I then assign a cost to each class based on the config in `cost_map.json` and then look for parts of the traversable spectrum that have ood depth and mark them as obstacles.